### PR TITLE
Search suggest

### DIFF
--- a/elasticmagic/agg.py
+++ b/elasticmagic/agg.py
@@ -4,15 +4,7 @@ from .document import DynamicDocument
 from .expression import QueryExpression, Params
 from .compat import force_unicode
 from .types import instantiate, Type
-from .util import _with_clone, cached_property, maybe_float
-
-
-def merge_aggregations(aggregations, args, kwargs):
-    aggs = dict(args[0] if args else {})
-    for a in args:
-        aggs.update(a)
-    aggs.update(kwargs)
-    return Params(aggregations, **aggs)
+from .util import _with_clone, cached_property, maybe_float, merge_params
 
 
 class AggExpression(QueryExpression):
@@ -52,7 +44,7 @@ class BucketAgg(AggExpression):
         if len(args) == 1 and args[0] is None:
             self._aggregations = Params()
         else:
-            self._aggregations = merge_aggregations(self._aggregations, args, kwargs)
+            self._aggregations = merge_params(self._aggregations, args, kwargs)
 
     aggs = aggregations
 

--- a/elasticmagic/cluster.py
+++ b/elasticmagic/cluster.py
@@ -219,8 +219,3 @@ class Cluster(object):
     def flush(self, index=None):
         params = clean_params({'index': index})
         return self._client.indices.flush(**params)
-
-    def suggest(self, q, index=None):
-        body = q.to_dict()['suggest']
-        params = clean_params({'index': index})
-        return self._client.suggest(body=body, **params)

--- a/elasticmagic/cluster.py
+++ b/elasticmagic/cluster.py
@@ -215,7 +215,12 @@ class Cluster(object):
     def refresh(self, index=None):
         params = clean_params({'index': index})
         return self._client.indices.refresh(**params)
-        
+
     def flush(self, index=None):
         params = clean_params({'index': index})
         return self._client.indices.flush(**params)
+
+    def suggest(self, q, index=None):
+        body = q.to_dict()['suggest']
+        params = clean_params({'index': index})
+        return self._client.suggest(body=body, **params)

--- a/elasticmagic/compiler.py
+++ b/elasticmagic/compiler.py
@@ -12,7 +12,7 @@ class Compiled(object):
     def __init__(self, expression):
         self.expression = expression
         self.params = self.visit(self.expression)
-        
+
     def visit(self, expr, **kwargs):
         visit_name = None
         if hasattr(expr, '__visit_name__'):
@@ -189,7 +189,7 @@ class QueryCompiled(Compiled):
 
     def visit_query_rescorer(self, rescorer):
         return {'query': self.visit(rescorer.params)}
-    
+
     def visit_rescore(self, rescore):
         params = self.visit(rescore.rescorer)
         if rescore.window_size is not None:
@@ -215,6 +215,8 @@ class QueryCompiled(Compiled):
             params['rescore'] = self.visit(query._rescores)
         if query._post_filters:
             params['post_filter'] = self.visit(query.get_post_filter())
+        if query._suggest:
+            params['suggest'] = self.visit(query._suggest)
         return params
 
 

--- a/elasticmagic/index.py
+++ b/elasticmagic/index.py
@@ -134,3 +134,6 @@ class Index(object):
         
     def flush(self):
         return self._cluster.flush(index=self._name)
+
+    def suggest(self, q):
+        return self._cluster.suggest(q, index=self._name)

--- a/elasticmagic/index.py
+++ b/elasticmagic/index.py
@@ -134,6 +134,3 @@ class Index(object):
         
     def flush(self):
         return self._cluster.flush(index=self._name)
-
-    def suggest(self, q):
-        return self._cluster.suggest(q, index=self._name)

--- a/elasticmagic/search.py
+++ b/elasticmagic/search.py
@@ -201,13 +201,12 @@ class SearchQuery(object):
         self._rescores = self._rescores + (rescore,)
 
     @_with_clone
-    def suggest(self, text=None, **suggests):
-        if text is None and not suggests:
+    def suggest(self, *args, **kwargs):
+        if args == (None,):
             if'_suggest' in self.__dict__:
                 del self._suggest
         else:
-            arg = ({'text': text},) if text else ()
-            self._suggest = merge_params(self._suggest, arg, suggests)
+            self._suggest = merge_params(self._suggest, args, kwargs)
 
     @_with_clone
     def instances(self):

--- a/elasticmagic/search.py
+++ b/elasticmagic/search.py
@@ -2,8 +2,7 @@ import warnings
 import collections
 from itertools import chain
 
-from .agg import merge_aggregations
-from .util import _with_clone, cached_property, clean_params, collect_doc_classes
+from .util import _with_clone, cached_property, clean_params, merge_params, collect_doc_classes
 from .result import Result
 from .compiler import QueryCompiled
 from .expression import Expression, QueryExpression, Params, Filtered, And, Bool, FunctionScore
@@ -165,7 +164,7 @@ class SearchQuery(object):
             if '_aggregations' in self.__dict__:
                 del self._aggregations
         else:
-            self._aggregations = merge_aggregations(self._aggregations, args, kwargs)
+            self._aggregations = merge_params(self._aggregations, args, kwargs)
 
     aggs = aggregations
 

--- a/elasticmagic/search.py
+++ b/elasticmagic/search.py
@@ -64,6 +64,7 @@ class SearchQuery(object):
     _limit = None
     _offset = None
     _rescores = ()
+    _suggest = Params()
 
     _cluster = None
     _index = None
@@ -198,6 +199,15 @@ class SearchQuery(object):
             return
         rescore = Rescore(rescorer, window_size=window_size)
         self._rescores = self._rescores + (rescore,)
+
+    @_with_clone
+    def suggest(self, text=None, **suggests):
+        if text is None and not suggests:
+            if'_suggest' in self.__dict__:
+                del self._suggest
+        else:
+            arg = ({'text': text},) if text else ()
+            self._suggest = merge_params(self._suggest, arg, suggests)
 
     @_with_clone
     def instances(self):

--- a/elasticmagic/util.py
+++ b/elasticmagic/util.py
@@ -1,3 +1,4 @@
+import collections
 from functools import wraps
 from itertools import chain
 
@@ -39,7 +40,8 @@ def collect_doc_classes(expr):
 
     if isinstance(expr, dict):
         return set().union(
-            *[collect_doc_classes(e) for e in chain(expr.keys(), expr.values())]
+            *[collect_doc_classes(e)
+              for e in chain(expr.keys(), expr.values())]
         )
 
     if isinstance(expr, (list, tuple)):
@@ -52,3 +54,13 @@ def maybe_float(value):
     if value is None:
         return None
     return float(value)
+
+
+def merge_params(params, args, kwargs):
+    assert isinstance(args, collections.Iterable), args
+    assert isinstance(kwargs, collections.Mapping), kwargs
+    new = dict()
+    for a in args:
+        new.update(a)
+    new.update(kwargs)
+    return type(params)(params, **new)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -935,7 +935,7 @@ class SearchQueryTest(BaseTestCase):
 
     def test_suggest(self):
         sq = SearchQuery()
-        sq = sq.suggest("Complete",
+        sq = sq.suggest(text="Complete",
                         in_title={'term': {'size': 3, 'field': 'title'}})
 
         self.assert_expression(
@@ -974,5 +974,5 @@ class SearchQueryTest(BaseTestCase):
             }
         )
 
-        sq = sq.suggest()
+        sq = sq.suggest(None)
         self.assert_expression(sq, {})

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -932,3 +932,47 @@ class SearchQueryTest(BaseTestCase):
                 'unknown_param': 'none',
             }
         )
+
+    def test_suggest(self):
+        sq = SearchQuery()
+        sq = sq.suggest("Complete",
+                        in_title={'term': {'size': 3, 'field': 'title'}})
+
+        self.assert_expression(
+            sq.to_dict(),
+            {
+                'suggest': {
+                    'text': 'Complete',
+                    'in_title': {
+                        'term': {
+                            'size': 3,
+                            'field': 'title',
+                        }
+                    }
+                }
+            }
+        )
+
+        sq = sq.suggest(in_body={'completion': {'field': 'body'}})
+        self.assert_expression(
+            sq,
+            {
+                'suggest': {
+                    'text': 'Complete',
+                    'in_title': {
+                        'term': {
+                            'size': 3,
+                            'field': 'title',
+                        }
+                    },
+                    'in_body': {
+                        'completion': {
+                            'field': 'body',
+                        }
+                    },
+                }
+            }
+        )
+
+        sq = sq.suggest()
+        self.assert_expression(sq, {})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+from .base import BaseTestCase
+
+from elasticmagic.util import merge_params
+from elasticmagic.expression import Params
+
+
+class UtilsTest(BaseTestCase):
+
+    def test_merge_params(self):
+        original = Params()
+        self.assertEqual(tuple(original.items()), ())
+
+        p = merge_params(original, (), {})
+        self.assertEqual(original, p)
+        self.assertIsNot(original, p)
+
+        p = merge_params(original, ({'key': 'value'},), {})
+        self.assertEqual(tuple(p.items()), (('key', 'value'),))
+        self.assertNotEqual(original, p)
+        self.assertIsNot(original, p)
+
+        p = merge_params(original, (), dict(key='value'))
+        self.assertEqual(tuple(p.items()), (('key', 'value'),))
+        self.assertNotEqual(original, p)
+        self.assertIsNot(original, p)
+
+        p = merge_params(p, ({'key': 'new value'}, ), {'foo': 'bar'})
+        self.assertEqual(sorted(p.items()),
+                         [('foo', 'bar'), ('key', 'new value')])
+
+        self.assertRaises(AssertionError,
+                          lambda: merge_params(original, None, {}))
+        self.assertRaises(AssertionError,
+                          lambda: merge_params(original, object(), {}))
+        self.assertRaises(AssertionError,
+                          lambda: merge_params(original, (), None))
+        self.assertRaises(AssertionError,
+                          lambda: merge_params(original, (), []))


### PR DESCRIPTION
Changes:
* `merge_annotations` renamed to `merge_params`;
* `merge_params` refactored and separate test added;
* `SearchQuery.suggest` method added allowing to construct suggesters queries
  (see https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-suggesters.html);
* some whitespaces cleaned up;