### PR TITLE
coveragerc: enable branch coverage measurement

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 include = elasticmagic/*
+branch = true


### PR DESCRIPTION
having coverage enabled is great, but its nothing without `branch = true` flag.