### PR TITLE
Reverse nested aggregation added

### DIFF
--- a/elasticmagic/agg.py
+++ b/elasticmagic/agg.py
@@ -814,6 +814,13 @@ class Nested(SingleBucketAgg):
         super(Nested, self).__init__(path=path, **kwargs)
 
 
+class ReverseNested(SingleBucketAgg):
+    __agg_name__ = 'reverse_nested'
+
+    def __init__(self, path, **kwargs):
+        super(ReverseNested, self).__init__(path=path, **kwargs)
+
+
 class Sampler(SingleBucketAgg):
     __agg_name__ = 'sampler'
 


### PR DESCRIPTION
This is important feature for aggregation on nested fields.

[Manual](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html)