### PR TITLE
Use stored fields when emulating mapping types

### DIFF
--- a/elasticmagic/agg.py
+++ b/elasticmagic/agg.py
@@ -27,8 +27,8 @@
 """
 from itertools import chain
 
-from .document import DOC_TYPE_FIELD_NAME
 from .document import DynamicDocument
+from .document import get_doc_type_for_hit
 from .expression import ParamsExpression, Params
 from .compat import force_unicode
 from .types import instantiate, Type
@@ -250,12 +250,7 @@ class TopHitsResult(AggResult):
 
         self.hits = []
         for hit in hits_data.get('hits', []):
-            fields = hit.get('fields', {})
-            custom_doc_type = fields.get(DOC_TYPE_FIELD_NAME)
-            if custom_doc_type:
-                doc_type = custom_doc_type[0]
-            else:
-                doc_type = hit['_type']
+            doc_type = get_doc_type_for_hit(hit)
             doc_cls = doc_cls_map.get(doc_type, DynamicDocument)
             self.hits.append(doc_cls(_hit=hit, _result=self))
 

--- a/elasticmagic/cluster.py
+++ b/elasticmagic/cluster.py
@@ -101,6 +101,9 @@ class BaseCluster(with_metaclass(ABCMeta)):
     def _put_mapping_params(self, params):
         return self._preprocess_params(params, 'doc_cls_or_mapping')
 
+    def _create_index_params(self, params):
+        return self._preprocess_params(params, 'settings', 'mappings')
+
     def _add_params(self, params):
         from . import actions
 

--- a/elasticmagic/cluster.py
+++ b/elasticmagic/cluster.py
@@ -132,12 +132,12 @@ class Cluster(BaseCluster):
         compiled_query = compiler(*args, **kwargs)
         api_method = compiled_query.api_method(self._client)
         if compiled_query.body is None:
-            return compiled_query.process_result(
-                api_method(**compiled_query.params)
+            raw_res = api_method(**compiled_query.params)
+        else:
+            raw_res = api_method(
+                body=compiled_query.body, **compiled_query.params
             )
-        return compiled_query.process_result(
-            api_method(body=compiled_query.body, **compiled_query.params)
-        )
+        return compiled_query.process_result(raw_res)
 
     def get_compiler(self):
         if self._compiler:

--- a/elasticmagic/compiler.py
+++ b/elasticmagic/compiler.py
@@ -9,6 +9,7 @@ from .compat import Iterable
 from .compat import Mapping
 from .compat import string_types
 from .document import DOC_TYPE_JOIN_FIELD
+from .document import DOC_TYPE_FIELD
 from .document import DOC_TYPE_NAME_FIELD
 from .document import DOC_TYPE_PARENT_FIELD
 from .document import Document
@@ -962,17 +963,22 @@ class CompiledPutMapping(CompiledEndpoint):
             properties[DOC_TYPE_JOIN_FIELD] = {
                 'type': 'join'
             }
-            properties[DOC_TYPE_NAME_FIELD] = {
-                'type': 'keyword',
-                'index': False,
-                'doc_values': False,
-                'store': True,
-            }
-            properties[DOC_TYPE_PARENT_FIELD] = {
-                'type': 'keyword',
-                'index': False,
-                'doc_values': False,
-                'store': True,
+            properties[DOC_TYPE_FIELD] = {
+                'type': 'object',
+                'properties': {
+                    'name': {
+                        'type': 'keyword',
+                        'index': False,
+                        'doc_values': False,
+                        'store': True,
+                    },
+                    'parent': {
+                        'type': 'keyword',
+                        'index': False,
+                        'doc_values': False,
+                        'store': True,
+                    }
+                }
             }
         mapping['properties'] = properties
         for f in doc_cls.dynamic_fields:
@@ -1297,14 +1303,13 @@ class CompiledSource(CompiledExpression):
 
         if _is_emulate_doc_types_mode(self.features, doc):
             doc_type_source = {}
-            source[DOC_TYPE_NAME_FIELD] = doc_type_source['name'] = \
-                doc.__doc_type__
+            doc_type_source['name'] = doc.__doc_type__
             if doc._parent is not None:
-                source[DOC_TYPE_PARENT_FIELD] = doc_type_source['parent'] = \
-                    mk_uid(
-                        doc.__parent__.__doc_type__,
-                        doc._parent
-                    )
+                doc_type_source['parent'] = mk_uid(
+                    doc.__parent__.__doc_type__,
+                    doc._parent
+                )
+            source[DOC_TYPE_FIELD] = doc_type_source
             source[DOC_TYPE_JOIN_FIELD] = doc_type_source
 
         return source

--- a/elasticmagic/document.py
+++ b/elasticmagic/document.py
@@ -7,9 +7,10 @@ from .util import cached_property
 from .compat import with_metaclass
 
 
-DOC_TYPE_JOIN_FIELD = '_doc_type'
-DOC_TYPE_NAME_FIELD = '_doc_type_name'
-DOC_TYPE_PARENT_FIELD = '_doc_type_parent'
+DOC_TYPE_FIELD = '_doc_type'
+DOC_TYPE_NAME_FIELD = '{}.name'.format(DOC_TYPE_FIELD)
+DOC_TYPE_PARENT_FIELD = '{}.parent'.format(DOC_TYPE_FIELD)
+DOC_TYPE_JOIN_FIELD = '_doc_type_join'
 DOC_TYPE_ID_DELIMITER = '~'
 DOC_TYPE_PARENT_DELIMITER = '#'
 

--- a/elasticmagic/expression.py
+++ b/elasticmagic/expression.py
@@ -635,12 +635,6 @@ class Field(Expression, FieldOperators):
     def get_mapping_options(self):
         return self._mapping_options
 
-    # def _to_python(self, value):
-    #     return self._type.to_python(value)
-
-    # def _from_python(self, value):
-    #     return self._type.from_python(value)
-
     def to_mapping(self, compiler):
         return compiler.compiled_put_mapping(self).body
 

--- a/elasticmagic/ext/asyncio/cluster.py
+++ b/elasticmagic/ext/asyncio/cluster.py
@@ -13,14 +13,12 @@ class AsyncCluster(BaseCluster):
         compiled_query = compiler(*args, **kwargs)
         api_method = compiled_query.api_method(self._client)
         if compiled_query.body is None:
-            return compiled_query.process_result(
-                await api_method(**compiled_query.params)
-            )
-        return compiled_query.process_result(
-            await api_method(
+            raw_res = await api_method(**compiled_query.params)
+        else:
+            raw_res = await api_method(
                 body=compiled_query.body, **compiled_query.params
             )
-        )
+        return compiled_query.process_result(raw_res)
 
     async def get_es_version(self):
         if not self._es_version:

--- a/elasticmagic/ext/asyncio/index.py
+++ b/elasticmagic/ext/asyncio/index.py
@@ -2,6 +2,9 @@ from ...index import BaseIndex
 
 
 class AsyncIndex(BaseIndex):
+    async def get_es_version(self):
+        return await self._cluster.get_es_version()
+
     async def get_compiler(self):
         return await self._cluster.get_compiler()
 

--- a/elasticmagic/index.py
+++ b/elasticmagic/index.py
@@ -49,6 +49,9 @@ class BaseIndex(with_metaclass(ABCMeta)):
 class Index(BaseIndex):
     # Methods that do requests to elasticsearch
 
+    def get_es_version(self):
+        return self._cluster.get_es_version()
+
     def get_compiler(self):
         return self._cluster.get_compiler()
 

--- a/requirements_async_test.txt
+++ b/requirements_async_test.txt
@@ -1,6 +1,7 @@
 mock
 setuptools
 nose
+attrs==19.1.0
 # https://github.com/pytest-dev/pytest-asyncio/issues/104
 pytest==4.0.2
 pytest-asyncio

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
 mock==1.3.0
 setuptools
 nose
+attrs==19.1.0
 pytest==4.0.2
 pytest-cov
 coverage

--- a/tests/test_parent_child.py
+++ b/tests/test_parent_child.py
@@ -71,19 +71,24 @@ def test_document_mapping_no_mapping_types(
         {
             'properties': {
                 '_doc_type': {
+                    'type': 'object',
+                    'properties': {
+                        'name': {
+                            'type': 'keyword',
+                            'index': False,
+                            'doc_values': False,
+                            'store': True
+                        },
+                        'parent': {
+                            'type': 'keyword',
+                            'index': False,
+                            'doc_values': False,
+                            'store': True
+                        },
+                    }
+                },
+                '_doc_type_join': {
                     'type': 'join'
-                },
-                '_doc_type_name': {
-                    'type': 'keyword',
-                    'index': False,
-                    'doc_values': False,
-                    'store': True
-                },
-                '_doc_type_parent': {
-                    'type': 'keyword',
-                    'index': False,
-                    'doc_values': False,
-                    'store': True
                 },
                 'question': {
                     'type': 'text'
@@ -135,22 +140,27 @@ def test_multiple_document_mappings_no_mapping_types(
         {
             'properties': {
                 '_doc_type': {
+                    'type': 'object',
+                    'properties': {
+                        'name': {
+                            'type': 'keyword',
+                            'index': False,
+                            'doc_values': False,
+                            'store': True
+                        },
+                        'parent': {
+                            'type': 'keyword',
+                            'index': False,
+                            'doc_values': False,
+                            'store': True
+                        },
+                    }
+                },
+                '_doc_type_join': {
                     'type': 'join',
                     'relations': {
                         'question': ['answer']
                     }
-                },
-                '_doc_type_name': {
-                    'type': 'keyword',
-                    'index': False,
-                    'doc_values': False,
-                    'store': True
-                },
-                '_doc_type_parent': {
-                    'type': 'keyword',
-                    'index': False,
-                    'doc_values': False,
-                    'store': True
                 },
                 'question': {
                     'type': 'text'
@@ -190,7 +200,9 @@ def test_document_meta_and_source_no_mapping_types(
             '_doc_type': {
                 'name': 'question'
             },
-            '_doc_type_name': 'question',
+            '_doc_type_join': {
+                'name': 'question'
+            },
             'question': 'The Ultimate Question'
         }
 
@@ -214,8 +226,10 @@ def test_document_meta_and_source_no_mapping_types(
                 'name': 'answer',
                 'parent': 'question~1',
             },
-            '_doc_type_name': 'answer',
-            '_doc_type_parent': 'question~1',
+            '_doc_type_join': {
+                'name': 'answer',
+                'parent': 'question~1',
+            },
             'answer': '42',
         }
 
@@ -265,7 +279,7 @@ def test_document_from_hit_no_mapping_types():
         '_id': 'question~1',
         '_type': '_doc',
         'fields': {
-            '_doc_type_name': ['question'],
+            '_doc_type.name': ['question'],
         },
         '_source': {
             'question': 'The Ultimate Question',
@@ -279,8 +293,8 @@ def test_document_from_hit_no_mapping_types():
         '_id': 'answer~1',
         '_type': '_doc',
         'fields': {
-            '_doc_type_name': ['answer'],
-            '_doc_type_parent': ['question~1'],
+            '_doc_type.name': ['answer'],
+            '_doc_type.parent': ['question~1'],
         },
         '_source': {
             'answer': '42',
@@ -380,7 +394,7 @@ def test_top_hits_agg(
     assert compiled_agg.body == {
         'top_hits': {
             'stored_fields': [
-                '_source', '_doc_type_name', '_doc_type_parent'
+                '_source', '_doc_type.name', '_doc_type.parent'
             ]
         }
     }
@@ -395,15 +409,15 @@ def test_top_hits_agg_result():
                     '_type': '_doc',
                     '_id': 'question~1',
                     'fields': {
-                        '_doc_type_name': ['question']
+                        '_doc_type.name': ['question']
                     }
                 },
                 {
                     '_type': '_doc',
                     '_id': 'answer~1',
                     'fields': {
-                        '_doc_type_name': ['answer'],
-                        '_doc_type_parent': ['question~1']
+                        '_doc_type.name': ['answer'],
+                        '_doc_type.parent': ['question~1']
                     }
                 }
             ]
@@ -448,7 +462,7 @@ def test_search_query_filter_by_ids_no_mapping_types(
                 }
             }
         },
-        'stored_fields': ['_source', '_doc_type_name', '_doc_type_parent']
+        'stored_fields': ['_source', '_doc_type.name', '_doc_type.parent']
     }
     assert compiled_query.params == {
         'doc_type': '_doc'
@@ -473,7 +487,7 @@ def test_search_query_filter_by_ids_no_mapping_types(
             }
         },
         'stored_fields': [
-            '_source', '_doc_type_name', '_doc_type_parent'
+            '_source', '_doc_type.name', '_doc_type.parent'
         ]
     }
     assert compiled_query.params == {
@@ -516,15 +530,15 @@ def test_process_search_result(
                         '_id': 'question~1',
                         '_type': '_doc',
                         'fields': {
-                            '_doc_type_name': ['question']
+                            '_doc_type.name': ['question']
                         }
                     },
                     {
                         '_id': 'answer~1',
                         '_type': '_doc',
                         'fields': {
-                            '_doc_type_name': ['answer'],
-                            '_doc_type_parent': ['question~1']
+                            '_doc_type.name': ['answer'],
+                            '_doc_type.parent': ['question~1']
                         }
                     },
                 ]
@@ -549,7 +563,7 @@ def test_get_no_mapping_types(compiler_no_mapping_types):
     assert compiled_get.params == {
         'doc_type': '_doc',
         'id': 'question~1',
-        'stored_fields': '_source,_doc_type_name,_doc_type_parent'
+        'stored_fields': '_source,_doc_type.name,_doc_type.parent'
     }
     compiled_get = compiler_no_mapping_types.compiled_get(
         {'id': 1}, doc_cls=Question
@@ -557,13 +571,13 @@ def test_get_no_mapping_types(compiler_no_mapping_types):
     assert compiled_get.params == {
         'doc_type': '_doc',
         'id': 'question~1',
-        'stored_fields': '_source,_doc_type_name,_doc_type_parent'
+        'stored_fields': '_source,_doc_type.name,_doc_type.parent'
     }
     compiled_get = compiler_no_mapping_types.compiled_get(Question(_id=1))
     assert compiled_get.params == {
         'doc_type': '_doc',
         'id': 'question~1',
-        'stored_fields': '_source,_doc_type_name,_doc_type_parent'
+        'stored_fields': '_source,_doc_type.name,_doc_type.parent'
     }
 
 
@@ -576,12 +590,12 @@ def test_multi_get_no_mapping_types(compiler_no_mapping_types):
             {
                 '_type': '_doc',
                 '_id': 'question~1',
-                'stored_fields': ['_source', '_doc_type_name', '_doc_type_parent']
+                'stored_fields': ['_source', '_doc_type.name', '_doc_type.parent']
             },
             {
                 '_type': '_doc',
                 '_id': 'answer~1',
-                'stored_fields': ['_source', '_doc_type_name', '_doc_type_parent']
+                'stored_fields': ['_source', '_doc_type.name', '_doc_type.parent']
             }
         ]
     }
@@ -593,12 +607,12 @@ def test_multi_get_no_mapping_types(compiler_no_mapping_types):
             {
                 '_type': '_doc',
                 '_id': 'question~1',
-                'stored_fields': ['_source', '_doc_type_name', '_doc_type_parent']
+                'stored_fields': ['_source', '_doc_type.name', '_doc_type.parent']
             },
             {
                 '_type': '_doc',
                 '_id': 'answer~1',
-                'stored_fields': ['_source', '_doc_type_name', '_doc_type_parent']
+                'stored_fields': ['_source', '_doc_type.name', '_doc_type.parent']
             }
         ]
     }
@@ -610,12 +624,12 @@ def test_multi_get_no_mapping_types(compiler_no_mapping_types):
             {
                 '_type': '_doc',
                 '_id': 'answer~1',
-                'stored_fields': ['_source', '_doc_type_name', '_doc_type_parent']
+                'stored_fields': ['_source', '_doc_type.name', '_doc_type.parent']
             },
             {
                 '_type': '_doc',
                 '_id': 'answer~2',
-                'stored_fields': ['_source', '_doc_type_name', '_doc_type_parent']
+                'stored_fields': ['_source', '_doc_type.name', '_doc_type.parent']
             }
         ]
     }

--- a/tests_integ/asyncio/test_parent_child.py
+++ b/tests_integ/asyncio/test_parent_child.py
@@ -6,6 +6,7 @@ from elasticmagic import (
     Field,
     Ids,
     HasParent, HasChild)
+from elasticmagic.compiler import CompilationError
 from elasticmagic.expression import ParentId
 from elasticmagic.types import (
     Float,
@@ -31,31 +32,45 @@ class Answer(Document):
 
 @pytest.fixture
 async def es_index(es_cluster, es_client, index_name):
-    await es_client.indices.create(
-        index=index_name,
-        body={'index': {
+    await es_cluster.create_index(
+        index_name,
+        settings={'index': {
             'number_of_shards': 1,
             'number_of_replicas': 0,
-        }}
+        }},
+        mappings=[Question, Answer],
     )
     es_index = es_cluster[index_name]
-    await es_index.put_mapping([Question, Answer])
     yield es_index
     await es_client.indices.delete(index=index_name)
 
 
 @pytest.fixture
 async def es_index_empty(es_cluster, es_client, index_name):
-    await es_client.indices.create(
-        index=index_name,
-        body={'index': {
+    class BaseQuestion(Document):
+        __doc_type__ = 'question'
+        __parent__ = None
+
+    class BaseAnswer(Document):
+        __doc_type__ = 'answer'
+        __parent__ = BaseQuestion
+
+    await es_cluster.create_index(
+        index_name,
+        settings={'index': {
             'number_of_shards': 1,
             'number_of_replicas': 0,
-        }}
+        }},
+        mappings=[BaseQuestion, BaseAnswer],
     )
     es_index = es_cluster[index_name]
     yield es_index
     await es_client.indices.delete(index=index_name)
+
+
+@pytest.fixture
+async def es_version(es_cluster):
+    yield await es_cluster.get_es_version()
 
 
 @pytest.fixture
@@ -86,151 +101,314 @@ async def docs(es_index):
     yield docs
 
 
-def check_question_meta(q):
+def check_question_meta(q, es_version):
     assert isinstance(q, Question)
     assert q._id == '1'
     assert q._type == 'question'
     assert q._routing is None
     assert q._parent is None
     fields = q.get_hit_fields()
-    assert fields['_doc_type.name'] == ['question']
+    if es_version.major < 6:
+        assert '_doc_type.name' not in fields
+    else:
+        assert fields['_doc_type.name'] == ['question']
 
 
-def check_standard_question_doc(q):
-    check_question_meta(q)
+def check_standard_question_doc(q, es_version):
+    check_question_meta(q, es_version)
     assert q.title == 'The Ultimate Question'
     assert q.text == \
         'The Ultimate Answer to Life, The Universe, and Everything'
     assert q.rank == 4.2
 
 
-def check_answer_meta(a):
+def check_answer_meta(a, es_version):
     assert isinstance(a, Answer)
     assert a._id == '1'
     assert a._type == 'answer'
     assert a._routing == '1'
     assert a._parent == '1'
     fields = a.get_hit_fields()
-    assert fields['_doc_type.name'] == ['answer']
-    assert fields['_doc_type.parent'] == ['question~1']
+    if es_version.major < 6:
+        assert '_doc_type.name' not in fields
+        assert '_doc_type.parent' not in fields
+    else:
+        assert fields['_doc_type.name'] == ['answer']
+        assert fields['_doc_type.parent'] == ['question~1']
 
 
-def check_standard_answer_doc(a):
-    check_answer_meta(a)
+def check_standard_answer_doc(a, es_version):
+    check_answer_meta(a, es_version)
     assert a.text == '42'
 
 
 @pytest.mark.asyncio
-async def test_update_mapping(es_client, index_name, es_index_empty):
-    await es_index_empty.put_mapping(Answer)
-    assert await es_client.indices.get_mapping(index_name) == {
-        index_name: {
-            'mappings': {
-                '_doc': {
-                    'properties': {
-                        '_doc_type': {
-                            'properties': {
-                                'name': {
-                                    'type': 'keyword',
-                                    'index': False,
-                                    'doc_values': False,
-                                    'store': True
-                                },
-                                'parent': {
-                                    'type': 'keyword',
-                                    'index': False,
-                                    'doc_values': False,
-                                    'store': True
-                                },
-                            }
+async def test_update_mapping(
+        es_client, es_version, index_name, es_index_empty
+):
+    if es_version.major < 6:
+        assert await es_client.indices.get_mapping(index_name) == {
+            index_name: {
+                'mappings': {
+                    'answer': {
+                        '_parent': {
+                            'type': 'question'
                         },
-                        '_doc_type_join': {
-                            'type': 'join',
-                            'relations': {},
-                            'eager_global_ordinals': True
-                        },
-                        'text': {
-                            'type': 'text'
+                        '_routing': {
+                            'required': True
                         }
-                    }
+                    },
+                    'question': {}
                 }
             }
         }
-    }
 
-    await es_index_empty.put_mapping([Question, Answer])
-    assert await es_client.indices.get_mapping(index_name) == {
-        index_name: {
-            'mappings': {
-                '_doc': {
-                    'properties': {
-                        '_doc_type': {
-                            'properties': {
-                                'name': {
-                                    'type': 'keyword',
-                                    'index': False,
-                                    'doc_values': False,
-                                    'store': True
-                                },
-                                'parent': {
-                                    'type': 'keyword',
-                                    'index': False,
-                                    'doc_values': False,
-                                    'store': True
-                                },
+        await es_index_empty.put_mapping(Answer)
+
+        assert await es_client.indices.get_mapping(index_name) == {
+            index_name: {
+                'mappings': {
+                    'answer': {
+                        '_parent': {
+                            'type': 'question'
+                        },
+                        '_routing': {
+                            'required': True
+                        },
+                        'properties': {
+                            'text': {
+                                'type': 'text'
                             }
+                        }
+                    },
+                    'question': {}
+                }
+            }
+        }
+
+        await es_index_empty.put_mapping(Question)
+        assert await es_client.indices.get_mapping(index_name) == {
+            index_name: {
+                'mappings': {
+                    'answer': {
+                        '_parent': {
+                            'type': 'question'
                         },
-                        '_doc_type_join': {
-                            'type': 'join',
-                            'relations': {
-                                'question': 'answer'
+                        '_routing': {
+                            'required': True
+                        },
+                        'properties': {
+                            'text': {
+                                'type': 'text'
+                            }
+                        }
+                    },
+                    'question': {
+                        'properties': {
+                            'title': {
+                                'type': 'text'
                             },
-                            'eager_global_ordinals': True
-                        },
-                        'title': {
-                            'type': 'text'
-                        },
-                        'text': {
-                            'type': 'text'
-                        },
-                        'rank': {
-                            'type': 'float',
-                            'store': True
+                            'text': {
+                                'type': 'text'
+                            },
+                            'rank': {
+                                'type': 'float',
+                                'store': True
+                            }
                         }
                     }
                 }
             }
         }
-    }
+
+        # TODO: Implement put_mapping([Answer, Question])
+        with pytest.raises(CompilationError):
+            await es_index_empty.put_mapping([Question, Answer])
+    else:
+        assert await es_client.indices.get_mapping(index_name) == {
+            index_name: {
+                'mappings': {
+                    '_doc': {
+                        'properties': {
+                            '_doc_type': {
+                                'properties': {
+                                    'name': {
+                                        'type': 'keyword',
+                                        'index': False,
+                                        'doc_values': False,
+                                        'store': True
+                                    },
+                                    'parent': {
+                                        'type': 'keyword',
+                                        'index': False,
+                                        'doc_values': False,
+                                        'store': True
+                                    },
+                                }
+                            },
+                            '_doc_type_join': {
+                                'type': 'join',
+                                'relations': {
+                                    'question': 'answer'
+                                },
+                                'eager_global_ordinals': True
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
+        await es_index_empty.put_mapping([Question, Answer])
+
+        assert await es_client.indices.get_mapping(index_name) == {
+            index_name: {
+                'mappings': {
+                    '_doc': {
+                        'properties': {
+                            '_doc_type': {
+                                'properties': {
+                                    'name': {
+                                        'type': 'keyword',
+                                        'index': False,
+                                        'doc_values': False,
+                                        'store': True
+                                    },
+                                    'parent': {
+                                        'type': 'keyword',
+                                        'index': False,
+                                        'doc_values': False,
+                                        'store': True
+                                    },
+                                }
+                            },
+                            '_doc_type_join': {
+                                'type': 'join',
+                                'relations': {
+                                    'question': 'answer'
+                                },
+                                'eager_global_ordinals': True
+                            },
+                            'title': {
+                                'type': 'text'
+                            },
+                            'text': {
+                                'type': 'text'
+                            },
+                            'rank': {
+                                'type': 'float',
+                                'store': True
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
 
 @pytest.mark.asyncio
-async def test_get_document(es_index, docs):
+async def test_get_document(es_index, es_version, docs):
     q = await es_index.get(Question(_id=1))
-    check_standard_question_doc(q)
+    check_standard_question_doc(q, es_version)
 
     a = await es_index.get(Answer(_id=1, _routing=1))
-    check_standard_answer_doc(a)
+    check_standard_answer_doc(a, es_version)
 
 
 @pytest.mark.asyncio
-async def test_get_document_with_stored_fields(es_index, docs):
+async def test_get_document_with_stored_fields(es_index, es_version, docs):
     q = await es_index.get(Question(_id=1), stored_fields='rank')
-    check_standard_question_doc(q)
+    check_question_meta(q, es_version)
+    assert q.title is None
+    assert q.text is None
+    assert q.rank is None
     assert q.get_hit_fields()['rank'] == [4.2]
 
 
 @pytest.mark.asyncio
-async def test_multi_get(es_index, docs):
-    docs = await es_index.multi_get(
-        [Question(_id=1), Answer(_id=1, _routing=1)]
+async def test_get_document_with_source(
+        es_index, es_version, docs
+):
+    q = await es_index.get(
+        Question(_id=1),
+        _source='title,rank',
     )
-    check_standard_question_doc(docs[0])
-    check_standard_answer_doc(docs[1])
+    check_question_meta(q, es_version)
+    assert q.title == 'The Ultimate Question'
+    assert q.text is None
+    assert q.rank == 4.2
 
 
 @pytest.mark.asyncio
-async def test_search(es_index, docs):
+async def test_get_document_no_source(
+        es_index, es_version, docs
+):
+    q = await es_index.get(
+        Question(_id=1),
+        _source=False,
+    )
+    check_question_meta(q, es_version)
+    assert q.title is None
+    assert q.text is None
+    assert q.rank is None
+
+
+@pytest.mark.asyncio
+async def test_get_document_with_stored_fields_and_source(
+        es_index, es_version, docs
+):
+    q = await es_index.get(
+        Question(_id=1),
+        stored_fields='rank',
+        _source=True,
+    )
+    check_standard_question_doc(q, es_version)
+    assert q.get_hit_fields()['rank'] == [4.2]
+
+
+@pytest.mark.asyncio
+async def test_get_document_with_stored_fields_and_source_include(
+        es_index, es_version, docs
+):
+    q = await es_index.get(
+        Question(_id=1),
+        stored_fields='rank',
+        _source_include='title',
+    )
+    check_question_meta(q, es_version)
+    assert q.title == 'The Ultimate Question'
+    assert q.text is None
+    assert q.rank is None
+    assert q.get_hit_fields()['rank'] == [4.2]
+
+
+@pytest.mark.asyncio
+async def test_get_document_with_stored_fields_and_source_exclude(
+        es_index, es_version, docs
+):
+    q = await es_index.get(
+        Question(_id=1),
+        stored_fields='rank',
+        _source_exclude='text',
+    )
+    check_question_meta(q, es_version)
+    assert q.title == 'The Ultimate Question'
+    assert q.text is None
+    assert q.rank == 4.2
+    assert q.get_hit_fields()['rank'] == [4.2]
+
+
+@pytest.mark.asyncio
+async def test_multi_get(es_index, es_version, docs):
+    docs = await es_index.multi_get(
+        [Question(_id=1), Answer(_id=1, _routing=1)]
+    )
+    check_standard_question_doc(docs[0], es_version)
+    check_standard_answer_doc(docs[1], es_version)
+
+
+@pytest.mark.asyncio
+async def test_search(es_index, es_version, docs):
     sq = es_index.search_query(doc_cls=[Answer, Question])
     res = await sq.get_result()
 
@@ -238,16 +416,16 @@ async def test_search(es_index, docs):
     assert len(res.hits) == 2
     assert res.error is None
 
-    check_standard_question_doc(res.hits[0])
+    check_standard_question_doc(res.hits[0], es_version)
 
-    check_standard_answer_doc(res.hits[1])
+    check_standard_answer_doc(res.hits[1], es_version)
 
     cached_res = await sq.get_result()
     assert cached_res is res
 
 
 @pytest.mark.asyncio
-async def test_search_no_source(es_index, docs):
+async def test_search_no_source(es_index, es_version, docs):
     sq = es_index.search_query(doc_cls=[Answer, Question]).source(False)
     res = await sq.get_result()
 
@@ -256,13 +434,13 @@ async def test_search_no_source(es_index, docs):
     assert res.error is None
 
     d = res.hits[0]
-    check_question_meta(d)
+    check_question_meta(d, es_version)
     assert d.title is None
     assert d.text is None
     assert d.rank is None
 
     d = res.hits[1]
-    check_answer_meta(d)
+    check_answer_meta(d, es_version)
     assert d.text is None
 
     cached_res = await sq.get_result()
@@ -270,7 +448,9 @@ async def test_search_no_source(es_index, docs):
 
 
 @pytest.mark.asyncio
-async def test_search_partial_source_and_stored_fields(es_index, docs):
+async def test_search_partial_source_and_stored_fields(
+        es_index, es_version, docs
+):
     sq = (
         es_index.search_query(doc_cls=[Answer, Question])
         .stored_fields(Question.rank)
@@ -283,22 +463,14 @@ async def test_search_partial_source_and_stored_fields(es_index, docs):
     assert res.error is None
 
     d = res.hits[0]
-    assert isinstance(d, Question)
-    assert d._id == '1'
-    assert d._type == 'question'
-    assert d._routing is None
-    assert d._parent is None
+    check_question_meta(d, es_version)
     assert d.title == 'The Ultimate Question'
     assert d.text is None
     assert d.rank is None
     assert d.get_hit_fields()['rank'] == [4.2]
 
     d = res.hits[1]
-    assert isinstance(d, Answer)
-    assert d._id == '1'
-    assert d._type == 'answer'
-    assert d._routing == '1'
-    assert d._parent == '1'
+    check_answer_meta(d, es_version)
     assert d.text is None
 
     cached_res = await sq.get_result()
@@ -306,7 +478,7 @@ async def test_search_partial_source_and_stored_fields(es_index, docs):
 
 
 @pytest.mark.asyncio
-async def test_top_hits_agg(es_index, docs):
+async def test_top_hits_agg(es_index, es_version, docs):
     sq = (
         es_index.search_query()
         .aggs({
@@ -329,31 +501,31 @@ async def test_top_hits_agg(es_index, docs):
     hits = b.get_aggregation('hits').hits
     assert len(hits) == 1
 
-    check_standard_question_doc(hits[0])
+    check_standard_question_doc(hits[0], es_version)
 
 
 @pytest.mark.asyncio
-async def test_ids_query(es_index, docs):
+async def test_ids_query(es_index, es_version, docs):
     sq = (
         es_index.search_query(doc_cls=[Question, Answer])
         .filter(Ids([1]))
     )
     res = await sq.get_result()
 
-    check_standard_question_doc(res.hits[0])
-    check_standard_answer_doc(res.hits[1])
+    check_standard_question_doc(res.hits[0], es_version)
+    check_standard_answer_doc(res.hits[1], es_version)
 
 
 @pytest.mark.asyncio
-async def test_parent_id_query(es_index, docs):
+async def test_parent_id_query(es_index, es_version, docs):
     sq = es_index.search_query(ParentId(Answer, 1))
     res = await sq.get_result()
 
-    check_standard_answer_doc(res.hits[0])
+    check_standard_answer_doc(res.hits[0], es_version)
 
 
 @pytest.mark.asyncio
-async def test_has_parent_query(es_index, docs):
+async def test_has_parent_query(es_index, es_version, docs):
     sq = (
         es_index.search_query(
             HasParent(
@@ -365,11 +537,11 @@ async def test_has_parent_query(es_index, docs):
     )
     res = await sq.get_result()
 
-    check_standard_answer_doc(res.hits[0])
+    check_standard_answer_doc(res.hits[0], es_version)
 
 
 @pytest.mark.asyncio
-async def test_has_child_query(es_index, docs):
+async def test_has_child_query(es_index, es_version, docs):
     sq = (
         es_index.search_query(
             HasChild(
@@ -381,4 +553,4 @@ async def test_has_child_query(es_index, docs):
     )
     res = await sq.get_result()
 
-    check_standard_question_doc(res.hits[0])
+    check_standard_question_doc(res.hits[0], es_version)

--- a/tests_integ/asyncio/test_parent_child.py
+++ b/tests_integ/asyncio/test_parent_child.py
@@ -93,7 +93,7 @@ def check_question_meta(q):
     assert q._routing is None
     assert q._parent is None
     fields = q.get_hit_fields()
-    assert fields['_doc_type_name'] == ['question']
+    assert fields['_doc_type.name'] == ['question']
 
 
 def check_standard_question_doc(q):
@@ -111,8 +111,8 @@ def check_answer_meta(a):
     assert a._routing == '1'
     assert a._parent == '1'
     fields = a.get_hit_fields()
-    assert fields['_doc_type_name'] == ['answer']
-    assert fields['_doc_type_parent'] == ['question~1']
+    assert fields['_doc_type.name'] == ['answer']
+    assert fields['_doc_type.parent'] == ['question~1']
 
 
 def check_standard_answer_doc(a):
@@ -129,21 +129,25 @@ async def test_update_mapping(es_client, index_name, es_index_empty):
                 '_doc': {
                     'properties': {
                         '_doc_type': {
+                            'properties': {
+                                'name': {
+                                    'type': 'keyword',
+                                    'index': False,
+                                    'doc_values': False,
+                                    'store': True
+                                },
+                                'parent': {
+                                    'type': 'keyword',
+                                    'index': False,
+                                    'doc_values': False,
+                                    'store': True
+                                },
+                            }
+                        },
+                        '_doc_type_join': {
                             'type': 'join',
                             'relations': {},
                             'eager_global_ordinals': True
-                        },
-                        '_doc_type_name': {
-                            'type': 'keyword',
-                            'index': False,
-                            'doc_values': False,
-                            'store': True
-                        },
-                        '_doc_type_parent': {
-                            'type': 'keyword',
-                            'index': False,
-                            'doc_values': False,
-                            'store': True
                         },
                         'text': {
                             'type': 'text'
@@ -161,23 +165,27 @@ async def test_update_mapping(es_client, index_name, es_index_empty):
                 '_doc': {
                     'properties': {
                         '_doc_type': {
+                            'properties': {
+                                'name': {
+                                    'type': 'keyword',
+                                    'index': False,
+                                    'doc_values': False,
+                                    'store': True
+                                },
+                                'parent': {
+                                    'type': 'keyword',
+                                    'index': False,
+                                    'doc_values': False,
+                                    'store': True
+                                },
+                            }
+                        },
+                        '_doc_type_join': {
                             'type': 'join',
                             'relations': {
                                 'question': 'answer'
                             },
                             'eager_global_ordinals': True
-                        },
-                        '_doc_type_name': {
-                            'type': 'keyword',
-                            'index': False,
-                            'doc_values': False,
-                            'store': True
-                        },
-                        '_doc_type_parent': {
-                            'type': 'keyword',
-                            'index': False,
-                            'doc_values': False,
-                            'store': True
                         },
                         'title': {
                             'type': 'text'

--- a/tests_integ/asyncio/test_parent_child.py
+++ b/tests_integ/asyncio/test_parent_child.py
@@ -1,0 +1,376 @@
+import pytest
+
+from elasticmagic import (
+    agg,
+    Document,
+    Field,
+    Ids,
+    HasParent, HasChild)
+from elasticmagic.expression import ParentId
+from elasticmagic.types import (
+    Float,
+    Text,
+)
+
+
+class Question(Document):
+    __doc_type__ = 'question'
+    __parent__ = None
+
+    title = Field(Text)
+    text = Field(Text)
+    rank = Field(Float, store=True)
+
+
+class Answer(Document):
+    __doc_type__ = 'answer'
+    __parent__ = Question
+
+    text = Field(Text)
+
+
+@pytest.fixture
+async def es_index(es_cluster, es_client, index_name):
+    await es_client.indices.create(
+        index=index_name,
+        body={'index': {
+            'number_of_shards': 1,
+            'number_of_replicas': 0,
+        }}
+    )
+    es_index = es_cluster[index_name]
+    await es_index.put_mapping([Question, Answer])
+    yield es_index
+    await es_client.indices.delete(index=index_name)
+
+
+@pytest.fixture
+async def es_index_empty(es_cluster, es_client, index_name):
+    await es_client.indices.create(
+        index=index_name,
+        body={'index': {
+            'number_of_shards': 1,
+            'number_of_replicas': 0,
+        }}
+    )
+    es_index = es_cluster[index_name]
+    yield es_index
+    await es_client.indices.delete(index=index_name)
+
+
+@pytest.fixture
+async def docs(es_index):
+    docs = [
+        Question(
+            _id=1,
+            title='The Ultimate Question',
+            text='The Ultimate Answer to Life, The Universe, and Everything',
+            rank=4.2,
+        ),
+        Answer(
+            _id=1,
+            _parent=1,
+            _routing=1,
+            text='42'
+        )
+    ]
+    res = await es_index.add(docs, refresh=True)
+    if res.errors:
+        error_msg = ''
+        for item in res.items:
+            if item.error:
+                error_msg += str(item.error.caused_by) + '\n'
+        raise ValueError(
+            'Errors when indexing fixtures:\n{}'.format(error_msg)
+        )
+    yield docs
+
+
+def check_question_meta(q):
+    assert isinstance(q, Question)
+    assert q._id == '1'
+    assert q._type == 'question'
+    assert q._routing is None
+    assert q._parent is None
+    fields = q.get_hit_fields()
+    assert fields['_doc_type_name'] == ['question']
+
+
+def check_standard_question_doc(q):
+    check_question_meta(q)
+    assert q.title == 'The Ultimate Question'
+    assert q.text == \
+        'The Ultimate Answer to Life, The Universe, and Everything'
+    assert q.rank == 4.2
+
+
+def check_answer_meta(a):
+    assert isinstance(a, Answer)
+    assert a._id == '1'
+    assert a._type == 'answer'
+    assert a._routing == '1'
+    assert a._parent == '1'
+    fields = a.get_hit_fields()
+    assert fields['_doc_type_name'] == ['answer']
+    assert fields['_doc_type_parent'] == ['question~1']
+
+
+def check_standard_answer_doc(a):
+    check_answer_meta(a)
+    assert a.text == '42'
+
+
+@pytest.mark.asyncio
+async def test_update_mapping(es_client, index_name, es_index_empty):
+    await es_index_empty.put_mapping(Answer)
+    assert await es_client.indices.get_mapping(index_name) == {
+        index_name: {
+            'mappings': {
+                '_doc': {
+                    'properties': {
+                        '_doc_type': {
+                            'type': 'join',
+                            'relations': {},
+                            'eager_global_ordinals': True
+                        },
+                        '_doc_type_name': {
+                            'type': 'keyword',
+                            'index': False,
+                            'doc_values': False,
+                            'store': True
+                        },
+                        '_doc_type_parent': {
+                            'type': 'keyword',
+                            'index': False,
+                            'doc_values': False,
+                            'store': True
+                        },
+                        'text': {
+                            'type': 'text'
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    await es_index_empty.put_mapping([Question, Answer])
+    assert await es_client.indices.get_mapping(index_name) == {
+        index_name: {
+            'mappings': {
+                '_doc': {
+                    'properties': {
+                        '_doc_type': {
+                            'type': 'join',
+                            'relations': {
+                                'question': 'answer'
+                            },
+                            'eager_global_ordinals': True
+                        },
+                        '_doc_type_name': {
+                            'type': 'keyword',
+                            'index': False,
+                            'doc_values': False,
+                            'store': True
+                        },
+                        '_doc_type_parent': {
+                            'type': 'keyword',
+                            'index': False,
+                            'doc_values': False,
+                            'store': True
+                        },
+                        'title': {
+                            'type': 'text'
+                        },
+                        'text': {
+                            'type': 'text'
+                        },
+                        'rank': {
+                            'type': 'float',
+                            'store': True
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_document(es_index, docs):
+    q = await es_index.get(Question(_id=1))
+    check_standard_question_doc(q)
+
+    a = await es_index.get(Answer(_id=1, _routing=1))
+    check_standard_answer_doc(a)
+
+
+@pytest.mark.asyncio
+async def test_get_document_with_stored_fields(es_index, docs):
+    q = await es_index.get(Question(_id=1), stored_fields='rank')
+    check_standard_question_doc(q)
+    assert q.get_hit_fields()['rank'] == [4.2]
+
+
+@pytest.mark.asyncio
+async def test_multi_get(es_index, docs):
+    docs = await es_index.multi_get(
+        [Question(_id=1), Answer(_id=1, _routing=1)]
+    )
+    check_standard_question_doc(docs[0])
+    check_standard_answer_doc(docs[1])
+
+
+@pytest.mark.asyncio
+async def test_search(es_index, docs):
+    sq = es_index.search_query(doc_cls=[Answer, Question])
+    res = await sq.get_result()
+
+    assert res.total == 2
+    assert len(res.hits) == 2
+    assert res.error is None
+
+    check_standard_question_doc(res.hits[0])
+
+    check_standard_answer_doc(res.hits[1])
+
+    cached_res = await sq.get_result()
+    assert cached_res is res
+
+
+@pytest.mark.asyncio
+async def test_search_no_source(es_index, docs):
+    sq = es_index.search_query(doc_cls=[Answer, Question]).source(False)
+    res = await sq.get_result()
+
+    assert res.total == 2
+    assert len(res.hits) == 2
+    assert res.error is None
+
+    d = res.hits[0]
+    check_question_meta(d)
+    assert d.title is None
+    assert d.text is None
+    assert d.rank is None
+
+    d = res.hits[1]
+    check_answer_meta(d)
+    assert d.text is None
+
+    cached_res = await sq.get_result()
+    assert cached_res is res
+
+
+@pytest.mark.asyncio
+async def test_search_partial_source_and_stored_fields(es_index, docs):
+    sq = (
+        es_index.search_query(doc_cls=[Answer, Question])
+        .stored_fields(Question.rank)
+        .source(include=[Question.title])
+    )
+    res = await sq.get_result()
+
+    assert res.total == 2
+    assert len(res.hits) == 2
+    assert res.error is None
+
+    d = res.hits[0]
+    assert isinstance(d, Question)
+    assert d._id == '1'
+    assert d._type == 'question'
+    assert d._routing is None
+    assert d._parent is None
+    assert d.title == 'The Ultimate Question'
+    assert d.text is None
+    assert d.rank is None
+    assert d.get_hit_fields()['rank'] == [4.2]
+
+    d = res.hits[1]
+    assert isinstance(d, Answer)
+    assert d._id == '1'
+    assert d._type == 'answer'
+    assert d._routing == '1'
+    assert d._parent == '1'
+    assert d.text is None
+
+    cached_res = await sq.get_result()
+    assert cached_res is res
+
+
+@pytest.mark.asyncio
+async def test_top_hits_agg(es_index, docs):
+    sq = (
+        es_index.search_query()
+        .aggs({
+            'ranks': agg.Histogram(
+                Question.rank,
+                interval=1.0,
+                min_doc_count=1,
+                aggs={
+                    'hits': agg.TopHits()
+                }
+            )
+        })
+    )
+    res = await sq.get_result()
+
+    ranks_agg = res.get_aggregation('ranks')
+    b = ranks_agg.buckets[0]
+    assert b.key == 4.0
+    assert b.doc_count == 1
+    hits = b.get_aggregation('hits').hits
+    assert len(hits) == 1
+
+    check_standard_question_doc(hits[0])
+
+
+@pytest.mark.asyncio
+async def test_ids_query(es_index, docs):
+    sq = (
+        es_index.search_query(doc_cls=[Question, Answer])
+        .filter(Ids([1]))
+    )
+    res = await sq.get_result()
+
+    check_standard_question_doc(res.hits[0])
+    check_standard_answer_doc(res.hits[1])
+
+
+@pytest.mark.asyncio
+async def test_parent_id_query(es_index, docs):
+    sq = es_index.search_query(ParentId(Answer, 1))
+    res = await sq.get_result()
+
+    check_standard_answer_doc(res.hits[0])
+
+
+@pytest.mark.asyncio
+async def test_has_parent_query(es_index, docs):
+    sq = (
+        es_index.search_query(
+            HasParent(
+                Question.title.match('ultimate')
+            ),
+            # TODO: document class can be detected automatically
+            doc_cls=Answer
+        )
+    )
+    res = await sq.get_result()
+
+    check_standard_answer_doc(res.hits[0])
+
+
+@pytest.mark.asyncio
+async def test_has_child_query(es_index, docs):
+    sq = (
+        es_index.search_query(
+            HasChild(
+                Answer.text.match('42')
+            ),
+            # TODO: document class can be detected automatically
+            doc_cls=Question
+        )
+    )
+    res = await sq.get_result()
+
+    check_standard_question_doc(res.hits[0])


### PR DESCRIPTION
`docvalue_fields` cannot be used with get and multi get api.