### PR TITLE
Add track_total_hits parameter support in search query body for Elasticsearch 7

### DIFF
--- a/elasticmagic/compiler.py
+++ b/elasticmagic/compiler.py
@@ -66,6 +66,7 @@ ElasticsearchFeatures = namedtuple(
         'supports_match_type',
         'supports_mapping_types',
         'supports_doc_type',
+        'supports_track_total_hits',
         'stored_fields_param',
         'script_source_field_name',
         'script_id_field_name',
@@ -801,6 +802,11 @@ class CompiledSearchQuery(CompiledExpression, CompiledEndpoint):
             params['script_fields'] = self.visit(
                 query_ctx.script_fields
             )
+        if (
+            self.features.supports_track_total_hits
+            and query_ctx.track_total_hits is not None
+        ):
+            params['track_total_hits'] = query_ctx.track_total_hits
         if not self.features.supports_mapping_types:
             self._patch_docvalue_fields(params, self.doc_classes)
         return params
@@ -1749,6 +1755,7 @@ def _featured_compiler(elasticsearch_features):
         supports_match_type=True,
         supports_mapping_types=True,
         supports_doc_type=True,
+        supports_track_total_hits=False,
         stored_fields_param='fields',
         script_source_field_name='script',
         script_id_field_name='script_id',
@@ -1775,6 +1782,7 @@ class Compiler_1_0(object):
         supports_match_type=True,
         supports_mapping_types=True,
         supports_doc_type=True,
+        supports_track_total_hits=False,
         stored_fields_param='fields',
         script_source_field_name='inline',
         script_id_field_name='id',
@@ -1801,6 +1809,7 @@ class Compiler_2_0(object):
         supports_match_type=True,
         supports_mapping_types=True,
         supports_doc_type=True,
+        supports_track_total_hits=False,
         stored_fields_param='stored_fields',
         script_source_field_name='inline',
         script_id_field_name='stored',
@@ -1827,6 +1836,7 @@ class Compiler_5_0(object):
         supports_match_type=True,
         supports_mapping_types=True,
         supports_doc_type=True,
+        supports_track_total_hits=False,
         stored_fields_param='stored_fields',
         script_source_field_name='source',
         script_id_field_name='id',
@@ -1853,6 +1863,7 @@ class Compiler_5_6(object):
         supports_match_type=False,
         supports_mapping_types=False,
         supports_doc_type=True,
+        supports_track_total_hits=False,
         stored_fields_param='stored_fields',
         script_source_field_name='source',
         script_id_field_name='id',
@@ -1879,6 +1890,7 @@ class Compiler_6_0(object):
         supports_match_type=False,
         supports_mapping_types=False,
         supports_doc_type=False,
+        supports_track_total_hits=True,
         stored_fields_param='stored_fields',
         script_source_field_name='source',
         script_id_field_name='id',

--- a/elasticmagic/compiler.py
+++ b/elasticmagic/compiler.py
@@ -803,8 +803,8 @@ class CompiledSearchQuery(CompiledExpression, CompiledEndpoint):
                 query_ctx.script_fields
             )
         if (
-            self.features.supports_track_total_hits
-            and query_ctx.track_total_hits is not None
+            self.features.supports_track_total_hits and
+            query_ctx.track_total_hits is not None
         ):
             params['track_total_hits'] = query_ctx.track_total_hits
         if not self.features.supports_mapping_types:

--- a/elasticmagic/search.py
+++ b/elasticmagic/search.py
@@ -73,6 +73,7 @@ class BaseSearchQuery(with_metaclass(ABCMeta)):
     _suggest = Params()
     _highlight = Params()
     _script_fields = Params()
+    _track_total_hits = None
 
     _cluster = None
     _index = None
@@ -91,6 +92,7 @@ class BaseSearchQuery(with_metaclass(ABCMeta)):
             cluster=None, index=None, doc_cls=None, doc_type=None,
             routing=None, preference=None, timeout=None, search_type=None,
             query_cache=None, terminate_after=None, scroll=None, stats=None,
+            track_total_hits=None,
             **kwargs
     ):
         if q is not None:
@@ -103,6 +105,8 @@ class BaseSearchQuery(with_metaclass(ABCMeta)):
             self._doc_cls = doc_cls
         if doc_type:
             self._doc_type = doc_type
+        if track_total_hits is not None:
+            self._track_total_hits = track_total_hits
 
         search_params = Params(
             routing=routing,
@@ -658,6 +662,10 @@ class BaseSearchQuery(with_metaclass(ABCMeta)):
     def with_instance_mapper(self, instance_mapper):
         self._instance_mapper = instance_mapper
 
+    @_with_clone
+    def with_track_total_hits(self, track_total_hits):
+        self._track_total_hits = track_total_hits
+
     def with_routing(self, routing):
         return self.with_search_params(routing=routing)
 
@@ -917,6 +925,7 @@ class SearchQueryContext(object):
         self.rescores = search_query._rescores
         self.suggest = search_query._suggest
         self.highlight = search_query._highlight
+        self.track_total_hits = search_query._track_total_hits
 
         self.cluster = search_query._cluster
         self.index = search_query._index

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -7,7 +7,7 @@ from elasticmagic import (
     SearchQuery, Params, Term, MultiMatch,
     FunctionScore, Sort, QueryRescorer, agg
 )
-from elasticmagic.compiler import Compiler_5_0
+from elasticmagic.compiler import Compiler_5_0, Compiler_7_0
 from elasticmagic.search import FunctionScoreSettings
 from elasticmagic.function import FieldValueFactor, Weight
 from elasticmagic.util import collect_doc_classes
@@ -672,6 +672,40 @@ class SearchQueryTest(BaseTestCase):
             }
         )
         self.assertEqual(collect_doc_classes(sq), {self.index['shirt']})
+
+        sq = SearchQuery()
+        self.assert_expression(
+            sq,
+            {},
+            compiler=Compiler_7_0,
+        )
+
+        sq = SearchQuery(track_total_hits=True)
+        self.assert_expression(
+            sq,
+            {
+                "track_total_hits": True,
+            },
+            compiler=Compiler_7_0,
+        )
+
+        sq = SearchQuery(track_total_hits=False)
+        self.assert_expression(
+            sq,
+            {
+                "track_total_hits": False,
+            },
+            compiler=Compiler_7_0,
+        )
+
+        sq = SearchQuery(track_total_hits=100)
+        self.assert_expression(
+            sq,
+            {
+                "track_total_hits": 100,
+            },
+            compiler=Compiler_7_0,
+        )
 
     def test_aggregations(self):
         f = DynamicDocument.fields


### PR DESCRIPTION
One of breaking changes in Elasticsearch 7 - by default search request will count the total hits accurately up to 10,000 documents (https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#track-total-hits-10000-default). Parameter `track_total_hits` must be persent in request body or in url params to get concrete number of documents which are results of search query. Parameter value may be boolean or number.

At this moment elasticmagic allows adding custom params to url, but `track_total_hits` does not work for multi search (must be only in body for each query) and count (it does not needed) queries with it in params. So it support in request body is also needed.