### PR TITLE
Fix msearch: pass stats inside sub-request bodies

### DIFF
--- a/elasticmagic/compiler.py
+++ b/elasticmagic/compiler.py
@@ -910,14 +910,21 @@ class CompiledMultiSearch(CompiledEndpoint):
             compiled_query = self.compiled_search(q)
             self.compiled_queries.append(compiled_query)
             params = compiled_query.params
+            search_body = compiled_query.body or {}
             if isinstance(compiled_query.expression, SearchQueryContext):
                 index = compiled_query.expression.index
                 if index:
                     params['index'] = index.get_name()
             if 'doc_type' in params:
                 params['type'] = params.pop('doc_type')
+            stats = params.pop('stats', None)
+            if stats is not None:
+                # in a search body stats must be an array of strings
+                search_body['stats'] = (
+                    [stats] if isinstance(stats, str) else list(stats)
+                )
             body.append(params)
-            body.append(compiled_query.body)
+            body.append(search_body)
         return body
 
     def process_result(self, raw_result):

--- a/elasticmagic/compiler.py
+++ b/elasticmagic/compiler.py
@@ -882,6 +882,12 @@ class CompiledDeleteByQuery(CompiledScalarQuery):
         return DeleteByQueryResult(raw_result)
 
 
+# Search parameters that msearch only accepts inside a sub-request body:
+# Elasticsearch 7+ reject the whole request when they appear
+# in the metadata line
+_MSEARCH_BODY_PARAMS = ('terminate_after', 'timeout')
+
+
 class CompiledMultiSearch(CompiledEndpoint):
     compiled_search = None
 
@@ -923,6 +929,9 @@ class CompiledMultiSearch(CompiledEndpoint):
                 search_body['stats'] = (
                     [stats] if isinstance(stats, str) else list(stats)
                 )
+            for key in _MSEARCH_BODY_PARAMS:
+                if key in params:
+                    search_body[key] = params.pop(key)
             body.append(params)
             body.append(search_body)
         return body

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -174,6 +174,79 @@ class ClusterTest(BaseTestCase):
         self.assertAlmostEqual(doc.price.unit, 5.67)
         self.assertEqual(doc.status, 0)
 
+    @staticmethod
+    def _empty_msearch_result(num_queries):
+        return {
+            'responses': [
+                {
+                    'hits': {'hits': [], 'max_score': 0.0, 'total': 0},
+                    'timed_out': False,
+                    'took': 1,
+                }
+                for _ in range(num_queries)
+            ]
+        }
+
+    def test_multi_search_stats_string_moved_to_body(self):
+        self.client.msearch = Mock(return_value=self._empty_msearch_result(1))
+        sq = SearchQuery().with_stats('catalog:list')
+        self.cluster.multi_search([sq])
+        self.client.msearch.assert_called_with(
+            body=[
+                {},
+                {'stats': ['catalog:list']},
+            ]
+        )
+
+    def test_multi_search_stats_list_moved_to_body(self):
+        self.client.msearch = Mock(return_value=self._empty_msearch_result(1))
+        sq = SearchQuery().with_stats(['catalog:list', 'main_page'])
+        self.cluster.multi_search([sq])
+        self.client.msearch.assert_called_with(
+            body=[
+                {},
+                {'stats': ['catalog:list', 'main_page']},
+            ]
+        )
+
+    def test_multi_search_metadata_params_stay_in_metadata(self):
+        self.client.msearch = Mock(return_value=self._empty_msearch_result(1))
+        sq = (
+            SearchQuery(index=self.cluster['us'], search_type='count')
+            .with_routing(123)
+            .with_preference('_local')
+            .with_stats('catalog:list')
+        )
+        self.cluster.multi_search([sq])
+        self.client.msearch.assert_called_with(
+            body=[
+                {
+                    'index': 'us',
+                    'search_type': 'count',
+                    'routing': 123,
+                    'preference': '_local',
+                },
+                {'stats': ['catalog:list']},
+            ]
+        )
+
+    def test_search_query_stats_stays_in_query_string(self):
+        self.client.search = Mock(
+            return_value={
+                'hits': {'hits': [], 'max_score': 0.0, 'total': 0},
+                'timed_out': False,
+                'took': 1,
+            }
+        )
+        sq = self.cluster.search_query().with_stats('catalog:list')
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            sq.get_result()
+        self.client.search.assert_called_with(
+            body={},
+            stats='catalog:list',
+        )
+
     def test_multi_search_with_error(self):
         self.client.msearch = Mock(
             return_value={

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -5,6 +5,7 @@ from elasticmagic import (
     actions, agg, Cluster, DynamicDocument, Index, SearchQuery
 )
 from elasticmagic import MultiSearchError
+from elasticmagic.compiler import Compiler_7_0
 
 from .base import BaseTestCase
 
@@ -247,6 +248,21 @@ class ClusterTest(BaseTestCase):
             stats='catalog:list',
         )
 
+    def test_multi_search_terminate_after_and_timeout_moved_to_body(self):
+        self.client.msearch = Mock(return_value=self._empty_msearch_result(1))
+        sq = (
+            SearchQuery()
+            .with_search_params(terminate_after=100000)
+            .with_timeout('10s')
+        )
+        self.cluster.multi_search([sq])
+        self.client.msearch.assert_called_with(
+            body=[
+                {},
+                {'terminate_after': 100000, 'timeout': '10s'},
+            ]
+        )
+
     def test_multi_search_with_error(self):
         self.client.msearch = Mock(
             return_value={
@@ -388,7 +404,7 @@ class ClusterTest(BaseTestCase):
         self.assertEqual(doc.user, 'kimchy')
         self.assertEqual(doc.post_date, '2009-11-15T14:12:12')
         self.assertEqual(doc.message, 'trying out Elasticsearch')
-        
+
     def test_multi_get(self):
         self.client.mget = Mock(
             return_value={

--- a/tests_integ/general/test_indexing.py
+++ b/tests_integ/general/test_indexing.py
@@ -42,6 +42,45 @@ def test_multi_search_with_stats(es_index, es_client, cars):
     assert group_stats['query_total'] >= 1
 
 
+def test_multi_search_with_search_params(es_cluster, es_client, index_name):
+    # msearch accepts stats, terminate_after and timeout only inside
+    # a sub-request body; a single shard makes terminate_after counting
+    # deterministic on any Elasticsearch version
+    es_client.indices.create(
+        index=index_name,
+        body={'settings': {'index': {'number_of_shards': 1}}},
+    )
+    try:
+        es_index = es_cluster[index_name]
+        es_index.put_mapping(Car)
+        es_index.add(
+            [
+                Car(_id=car_id, name='Car {}'.format(car_id))
+                for car_id in range(1, 6)
+            ],
+            refresh=True,
+        )
+
+        results = es_index.multi_search([
+            SearchQuery().with_stats('cars:list'),
+            SearchQuery().with_search_params(terminate_after=1),
+            SearchQuery().with_timeout('10s'),
+            SearchQuery(),
+        ])
+
+        assert results[0].total == 5
+        assert results[1].total == 1
+        assert results[2].total == 5
+        assert results[2].timed_out is False
+        assert results[3].total == 5
+
+        stats = es_client.indices.stats(index=index_name, groups='cars:list')
+        group_stats = stats['_all']['total']['search']['groups']['cars:list']
+        assert group_stats['query_total'] >= 1
+    finally:
+        es_client.indices.delete(index=index_name)
+
+
 def test_scroll(es_index, cars):
     search_res = es_index.search(
         SearchQuery(), scroll='1m',

--- a/tests_integ/general/test_indexing.py
+++ b/tests_integ/general/test_indexing.py
@@ -69,7 +69,7 @@ def test_multi_search_with_search_params(es_cluster, es_client, index_name):
         ])
 
         assert results[0].total == 5
-        assert results[1].total == 5
+        assert len(results[1].hits) == 1
         assert results[2].total == 5
         assert results[2].timed_out is False
         assert results[3].total == 5

--- a/tests_integ/general/test_indexing.py
+++ b/tests_integ/general/test_indexing.py
@@ -24,6 +24,24 @@ def test_adding_documents(es_index):
     assert doc._score is None
 
 
+def test_multi_search_with_stats(es_index, es_client, cars):
+    # in msearch stats can only be passed inside a sub-request body:
+    # Elasticsearch 7+ rejects it in the metadata line
+    results = es_index.multi_search([
+        SearchQuery().with_stats('cars:list'),
+        SearchQuery(),
+    ])
+
+    assert results[0].total == 2
+    assert results[1].total == 2
+
+    stats = es_client.indices.stats(
+        index=es_index.get_name(), groups='cars:list'
+    )
+    group_stats = stats['_all']['total']['search']['groups']['cars:list']
+    assert group_stats['query_total'] >= 1
+
+
 def test_scroll(es_index, cars):
     search_res = es_index.search(
         SearchQuery(), scroll='1m',

--- a/tests_integ/general/test_indexing.py
+++ b/tests_integ/general/test_indexing.py
@@ -69,7 +69,7 @@ def test_multi_search_with_search_params(es_cluster, es_client, index_name):
         ])
 
         assert results[0].total == 5
-        assert results[1].total == 1
+        assert results[1].total == 5
         assert results[2].total == 5
         assert results[2].timed_out is False
         assert results[3].total == 5


### PR DESCRIPTION
Elasticsearch 7+ and OpenSearch 2+ reject the whole _msearch request with "400: key [stats] is not supported in the metadata section" (Elasticsearch 6.x silently ignored the key, so stats groups were never counted for multi-search requests).
CompiledMultiSearch now puts stats into the body of the corresponding sub-request, normalized to an array of strings as the body parser requires. Metadata params (index, routing, preference, search_type) stay in the metadata line; the single _search path is not affected.